### PR TITLE
added "unfinished" as a new library browser filter

### DIFF
--- a/app/src/main/java/com/nkanaev/comics/fragment/LibraryBrowserFragment.java
+++ b/app/src/main/java/com/nkanaev/comics/fragment/LibraryBrowserFragment.java
@@ -97,6 +97,7 @@ public class LibraryBrowserFragment extends Fragment
             case R.id.menu_browser_filter_all:
             case R.id.menu_browser_filter_read:
             case R.id.menu_browser_filter_unread:
+            case R.id.menu_browser_filter_unfinished:
             case R.id.menu_browser_filter_reading:
                 item.setChecked(true);
                 mFilterRead = item.getItemId();
@@ -143,6 +144,8 @@ public class LibraryBrowserFragment extends Fragment
                 if (mFilterRead == R.id.menu_browser_filter_read && c.getCurrentPage() != c.getTotalPages())
                     continue;
                 if (mFilterRead == R.id.menu_browser_filter_unread && c.getCurrentPage() != 0)
+                    continue;
+                if (mFilterRead == R.id.menu_browser_filter_unfinished && c.getCurrentPage() == c.getTotalPages())
                     continue;
                 if (mFilterRead == R.id.menu_browser_filter_reading &&
                         (c.getCurrentPage() == 0 || c.getCurrentPage() == c.getTotalPages()))

--- a/app/src/main/res/menu/browser.xml
+++ b/app/src/main/res/menu/browser.xml
@@ -20,6 +20,8 @@
                       android:title="@string/menu_browser_filter_unread"/>
                 <item android:id="@+id/menu_browser_filter_reading"
                       android:title="@string/menu_browser_filter_reading"/>
+                <item android:id="@+id/menu_browser_filter_unfinished"
+                    android:title="@string/menu_browser_filter_unfinished"/>
                 <item android:id="@+id/menu_browser_filter_read"
                       android:title="@string/menu_browser_filter_read"/>
             </group>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,5 @@
     <string name="switch_prev_comic">Would you like to switch to the previous comic?</string>
 
     <string name="library_empty">Your collection seems empty. Click \"folder\" icon to select library directory</string>
+    <string name="menu_browser_filter_unfinished">Unfinished</string>
 </resources>


### PR DESCRIPTION
I thought it was annoying that if you started to read a comic that it disappeared when you choose the unread view. Thus it's a mix of "currently reading" and "unread". 