### PR TITLE
Mark as read checkbox

### DIFF
--- a/app/src/main/java/com/nkanaev/comics/managers/DirectoryListingManager.java
+++ b/app/src/main/java/com/nkanaev/comics/managers/DirectoryListingManager.java
@@ -12,9 +12,10 @@ import java.util.List;
 public class DirectoryListingManager {
     private final List<Comic> mComics;
     private final List<String> mDirectoryDisplays;
+    private final List<Boolean> mIsRead;
     private final File mLibraryDir;
 
-    public DirectoryListingManager(List<Comic> comics, String libraryDir) {
+    public DirectoryListingManager(List<Comic> comics, List<Boolean> areAllRead, String libraryDir) {
         Collections.sort(comics, new Comparator<Comic>() {
             @Override
             public int compare(Comic lhs, Comic rhs) {
@@ -24,6 +25,7 @@ public class DirectoryListingManager {
             }
         });
         mComics = comics;
+        mIsRead = new ArrayList<>(areAllRead);
         mLibraryDir = new File(libraryDir != null ? libraryDir : "/");
 
         List<String> directoryDisplays = new ArrayList<>();
@@ -58,6 +60,10 @@ public class DirectoryListingManager {
 
     public String getDirectoryDisplayAtIndex(int idx) {
         return mDirectoryDisplays.get(idx);
+    }
+
+    public Boolean getReadStatusAtIndex(int idx) {
+        return mIsRead.get(idx);
     }
 
     public Comic getComicAtIndex(int idx) {

--- a/app/src/main/java/com/nkanaev/comics/model/Comic.java
+++ b/app/src/main/java/com/nkanaev/comics/model/Comic.java
@@ -44,6 +44,14 @@ public class Comic implements Comparable {
         mCurrentPage = page;
     }
 
+    public boolean isRead() {
+        return mCurrentPage == mNumPages;
+    }
+
+    public boolean isStarted() {
+        return mCurrentPage != 0;
+    }
+
     public String getType() {
         return mType;
     }
@@ -55,5 +63,22 @@ public class Comic implements Comparable {
     @Override
     public boolean equals(Object o) {
         return (o instanceof Comic) && getId() == ((Comic)o).getId();
+    }
+
+    @Override
+    public int hashCode() {
+        return mId;
+    }
+
+    @Override
+    public String toString() {
+        return "Comic{" +
+                "mCurrentPage=" + mCurrentPage +
+                ", mNumPages=" + mNumPages +
+                ", mId=" + mId +
+                ", mType='" + mType + '\'' +
+                ", mFile=" + mFile +
+                ", updatedAt=" + updatedAt +
+                '}';
     }
 }

--- a/app/src/main/java/com/nkanaev/comics/view/IsReadImageView.java
+++ b/app/src/main/java/com/nkanaev/comics/view/IsReadImageView.java
@@ -1,0 +1,40 @@
+package com.nkanaev.comics.view;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+import com.nkanaev.comics.R;
+
+/**
+ * Created by sean on 01/10/17.
+ */
+
+public class IsReadImageView extends ImageView {
+
+    public static final int CHECKBOX_TICKED = R.drawable.abc_btn_check_to_on_mtrl_015;
+    public static final int CHECKBOX_EMPTY = R.drawable.abc_btn_check_to_on_mtrl_000;
+
+    public static final int COLOUR_READ = R.color.circle_green;
+    public static final int COLOUR_UNREAD = R.color.darkest;
+
+    private boolean isRead = false;
+
+    public IsReadImageView(Context context) {
+        super(context);
+    }
+
+    public IsReadImageView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public boolean isRead() {
+        return isRead;
+    }
+
+    public void setIsRead(boolean isRead) {
+        this.isRead = isRead;
+        this.setImageResource(isRead ? CHECKBOX_TICKED : CHECKBOX_EMPTY);
+        this.setColorFilter(getResources().getColor(isRead ? COLOUR_READ : COLOUR_UNREAD));
+    }
+}

--- a/app/src/main/res/layout/card_comic.xml
+++ b/app/src/main/res/layout/card_comic.xml
@@ -9,7 +9,7 @@
         cardview:cardCornerRadius="2dp"
         cardview:cardElevation="2dp"
         cardview:cardBackgroundColor="@color/lightest">
-    <LinearLayout
+    <RelativeLayout
             android:id="@+id/comicLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -18,7 +18,10 @@
         <com.nkanaev.comics.view.CoverImageView
                 android:id="@+id/comicImageView"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"/>
+                android:layout_height="0dp"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true" />
         <TextView
                 android:id="@+id/comicTitleTextView"
                 android:layout_width="match_parent"
@@ -27,7 +30,15 @@
                 android:paddingRight="@dimen/card_padding"
                 android:paddingTop="@dimen/card_padding"
                 android:lines="2"
-                android:textSize="@dimen/card_text"/>
+                android:textSize="@dimen/card_text"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_below="@+id/comicImageView"
+                android:layout_toStartOf="@+id/comicIsReadImageView"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true"
+                android:layout_toLeftOf="@+id/comicIsReadImageView" />
+
         <TextView
                 android:id="@+id/comicPagerTextView"
                 android:layout_width="match_parent"
@@ -36,6 +47,19 @@
                 android:textStyle="bold"
                 android:singleLine="true"
                 android:gravity="bottom|start"
-                android:textSize="@dimen/card_subtext"/>
-    </LinearLayout>
+                android:textSize="@dimen/card_subtext"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_toLeftOf="@+id/comicIsReadImageView"
+                android:layout_toStartOf="@+id/comicIsReadImageView"
+                android:layout_below="@+id/comicTitleTextView" />
+        <com.nkanaev.comics.view.IsReadImageView
+                android:id="@+id/comicIsReadImageView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/is_read_checkbox"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true" />
+    </RelativeLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/card_group.xml
+++ b/app/src/main/res/layout/card_group.xml
@@ -7,7 +7,7 @@
         cardview:cardCornerRadius="2dp"
         cardview:cardElevation="2dp"
         cardview:cardBackgroundColor="@color/lightest">
-    <LinearLayout
+    <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -15,14 +15,30 @@
         <com.nkanaev.comics.view.GroupImageView
                 android:id="@+id/card_group_imageview"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"/>
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true" />
         <TextView
                 android:id="@+id/comic_group_folder"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
+                android:layout_height="wrap_content"
                 android:padding="@dimen/card_padding"
                 android:singleLine="true"
-                android:layout_weight="1"
-                android:textSize="@dimen/card_text"/>
-    </LinearLayout>
+                android:textSize="@dimen/card_text"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_toLeftOf="@+id/comic_group_isRead"
+                android:layout_toStartOf="@+id/comic_group_isRead"
+                android:layout_below="@id/card_group_imageview" />
+        <com.nkanaev.comics.view.IsReadImageView
+                android:id="@+id/comic_group_isRead"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/is_read_checkbox"
+                android:layout_below="@id/card_group_imageview"
+                android:layout_alignBottom="@id/comic_group_folder"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentEnd="true" />
+    </RelativeLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -36,4 +36,5 @@
     <string name="menu_browser_filter_unread">Ungelesen</string>
     <string name="menu_library">Bibliothek</string>
     <string name="reload">Neu laden</string>
+    <string name="is_read_checkbox">Ist komisch lesen checkbox</string> <!-- Google Translate -->
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,4 +49,6 @@
 
     <string name="library_empty">Su colección parece vacía. Haz clic en el icono \"carpeta\" para seleccionar el directorio de la Biblioteca</string>
     <string name="warning_missing_file">Faltan archivos. Por favor, actualice la Biblioteca</string>
+
+    <string name="is_read_checkbox">Es una casilla de verificación de lectura cómica</string> <!-- Google Translate -->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,4 +57,6 @@
     <string name="warning_missing_file"></string>
     <string name="library_header_all"></string>
     <string name="library_header_recent"></string>
+
+    <string name="is_read_checkbox">La case à cocher est-elle une bande dessinée?</string> <!-- Google Translate -->
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -49,4 +49,6 @@
 
     <string name="library_empty">Colecția dvs. pare goalã. Apăsați pictograma \"folder\" pentru a selecta directorul bibliotecii</string>
     <string name="warning_missing_file">Lipsește fișierul. Vă rugăm actualizați biblioteca</string>
+
+    <string name="is_read_checkbox">Este bifată căsuța de citire comic</string> <!-- Google Translate -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,6 @@
 
     <string name="library_empty">Your collection seems empty. Click \"folder\" icon to select library directory</string>
     <string name="warning_missing_file">Missing file. Please update the library</string>
+
+    <string name="is_read_checkbox">Is comic read checkbox</string>
 </resources>


### PR DESCRIPTION
This PR adds a new checkbox to the library and comic cards.

It serves two purposes,
1. To display the read completion status of a comic (and a library of comics).
2. It allows users to manually mark a comic (and a library of comics) as read.

I'm not a seasoned Android developer so the code may not follow best practices, if there are any changes or improvements that you would like to see before merging to the main project let me know and I'll be happy to make them.

**Library view**
Example at the top level, library view.
![screenshot_20171002-215652](https://user-images.githubusercontent.com/1682260/31099226-317c7d9a-a7bd-11e7-8457-ced612c82a3c.png)

**Comic view**
Example at a comic book level.
![screenshot_20171002-215802](https://user-images.githubusercontent.com/1682260/31099227-318029ae-a7bd-11e7-8762-b286c3306b7f.png)
